### PR TITLE
[FIX] destination buffer of galois_wxx_region_multiply

### DIFF
--- a/src/galois.c
+++ b/src/galois.c
@@ -304,6 +304,10 @@ void galois_w08_region_multiply(char *region,      /* Region to multiply */
   if (gfp_array[8] == NULL) {
     galois_init(8);
   }
+  if (r2 == NULL) {
+    r2 = region;
+    add = 0; 
+  }
   gfp_array[8]->multiply_region.w32(gfp_array[8], region, r2, multby, nbytes, add);
 }
 
@@ -315,6 +319,10 @@ void galois_w16_region_multiply(char *region,      /* Region to multiply */
 {
   if (gfp_array[16] == NULL) {
     galois_init(16);
+  }
+  if (r2 == NULL) {
+    r2 = region;
+    add = 0; 
   }
   gfp_array[16]->multiply_region.w32(gfp_array[16], region, r2, multby, nbytes, add);
 }
@@ -328,6 +336,10 @@ void galois_w32_region_multiply(char *region,      /* Region to multiply */
 {
   if (gfp_array[32] == NULL) {
     galois_init(32);
+  }
+  if (r2 == NULL) {
+    r2 = region;
+    add = 0; 
   }
   gfp_array[32]->multiply_region.w32(gfp_array[32], region, r2, multby, nbytes, add);
 }


### PR DESCRIPTION
The manual says that if the dest buffer is NULL, then the result of
multiplication will go to the source region buffer. However,
multiply_region.w32 function, which is called by  galois_wxx_region_multiply,
assumes that the destination buffer is not NULL.

The proposed fix assigns destination buffer to source buffer if destination buffer is NULL.